### PR TITLE
Fix/flotiq-purge

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ This command will:
 
 ### Purge data in Flotiq account
 
-`flotiq purge [flotiqApiKey] [options]`
+`flotiq purge [flotiqApiKey] [flags]`
 
 This command will remove all data from your account. Great for testing imports. Command require additional confirmation.
 
@@ -81,7 +81,7 @@ This command will remove all data from your account. Great for testing imports. 
 * `flotiqApiKey` - read and write API key to your Flotiq account
 
 **Flags**
-* `--withInternal` or `--internal` - purge will also remove internal type objects  like (`_media`)
+* `--withInternal` or `--internal` - purge will also remove internal type objects like (`_media`)
 * `--force` or `--f` - purge will remove data even if Content Types relations loop to each other.
 
 ### Export data from Flotiq to json files

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ This command will:
 
 ### Purge data in Flotiq account
 
-`flotiq purge [flotiqApiKey] [flags]`
+`flotiq purge [flotiqApiKey]`
 
 This command will remove all data from your account. Great for testing imports. Command require additional confirmation.
 

--- a/README.md
+++ b/README.md
@@ -79,8 +79,10 @@ This command will remove all data from your account. Great for testing imports. 
 
 **Parameters**
 * `flotiqApiKey` - read and write API key to your Flotiq account
-* `options` - additional options for command:
-  * `withInternal=1` - purge should remove also internal type objects (`_media`)
+
+**Flags**
+* `--withInternal` or `--internal` - purge will also remove internal type objects  like (`_media`)
+* `--force` or `--f` - purge will remove data even if Content Types relations loop to each other.
 
 ### Export data from Flotiq to json files
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "gatsby-cli": "^4.2.0",
     "inquirer": "^7.2.0",
     "node-fetch": "^2.6.1",
+    "ora": "^5.4.1",
     "unzipper": "^0.10.11",
     "yargs": "^15.3.1"
   },

--- a/src/command/command.js
+++ b/src/command/command.js
@@ -121,27 +121,41 @@ yargs
         }
     })
     .command(
-        'purge [flotiqApiKey] [options]',
+        'purge [flotiqApiKey] [withInternal] [force]',
         'Purge Flotiq account, removes all objects to which the key has access',
         (yargs) => {
             optionalParamFlotiqApiKey(yargs);
-        }, async (argv) => {
-            if (yargs.argv._.length < 2 && !apiKeyDefinedInDotEnv()) {
-                console.log('Api key not found')
-            } else if(yargs.argv._.length === 1 && apiKeyDefinedInDotEnv()) {
-                await purgeContentObjects(argv.flotiqApiKey, argv.withInternal);
-            } else if (yargs.argv._.length === 2) {
+            yargs
+                .boolean('force')
+                .alias('force', ['f'])
+                .describe('force', 'force removing content objects when function gets stuck')
+                .boolean('withInternal')
+                .alias('withInternal', ['internal'])
+                .describe('withInternal', 'remove objects from internal CTD like _media')
+        }, (argv) => {
+            const purge = async (apiKey, withInternal, force) => {
                 const answers = await askQuestions(questionsText.PURGE_QUESTION);
-                const {confirmation} = answers;
-                if (!argv.flotiqApiKey && apiKeyDefinedInDotEnv()) {
-                    argv.flotiqApiKey = process.env.FLOTIQ_API_KEY;
-                }
+                const { confirmation } = answers;
                 if (confirmation.toUpperCase() === 'Y') {
-                    await purgeContentObjects(argv.flotiqApiKey, argv.withInternal);
+                    await purgeContentObjects(apiKey, withInternal, force);
                 } else {
                     console.log('I\'m finishing, no data has been deleted');
                     process.exit(1);
                 }
+            }
+            
+            if (yargs.argv._.length < 2 && !apiKeyDefinedInDotEnv()) {
+                console.log('Api key not found')
+            } else if (yargs.argv._.length === 1 && apiKeyDefinedInDotEnv()) {
+                purge(process.env.FLOTIQ_API_KEY);
+            } else if (yargs.argv._.length <= 3 && apiKeyDefinedInDotEnv() || yargs.argv._.length <= 4) {
+                if (!argv.flotiqApiKey && apiKeyDefinedInDotEnv()) {
+                    argv.flotiqApiKey = process.env.FLOTIQ_API_KEY;
+                }
+                purge(argv.flotiqApiKey, yargs.argv['withInternal'], yargs.argv['force'])
+            } else {
+                yargs.showHelp();
+                process.exit(1);
             }
         })
     .command(

--- a/src/command/command.js
+++ b/src/command/command.js
@@ -121,7 +121,7 @@ yargs
         }
     })
     .command(
-        'purge [flotiqApiKey] [withInternal] [force]',
+        'purge [flotiqApiKey]',
         'Purge Flotiq account, removes all objects to which the key has access',
         (yargs) => {
             optionalParamFlotiqApiKey(yargs);

--- a/src/flotiq-api/flotiq-api.js
+++ b/src/flotiq-api/flotiq-api.js
@@ -25,6 +25,15 @@ const fetchMedia = async (apiKey, page = 1, limit = 10) => {
     return await media.json();
 }
 
+const updateContentTypeDefinition = async (data, apiKey) => {
+    return fetch(`${config.apiUrl}/api/v1/internal/contenttype/${data.name}`, {
+        method: 'PUT',
+        body: JSON.stringify(data),
+        headers: { 'Content-Type': 'application/json', 'X-AUTH-TOKEN': apiKey },
+        json: true
+    });
+}
+
 const flotiqCtdUpload = async (data, apiKey) => {
     headers['X-AUTH-TOKEN'] = apiKey;
 
@@ -99,6 +108,7 @@ module.exports = {
     fetchContentTypeDefinitions,
     fetchContentObjects,
     fetchMedia,
+    updateContentTypeDefinition,
     flotiqCtdUpload,
     flotiqCoUploadByCtd,
     flotiqMediaUpload

--- a/src/purifier/purifier.js
+++ b/src/purifier/purifier.js
@@ -12,7 +12,6 @@ module.exports = purgeContentObjects = async (apiKey, internal = false, force = 
 
     let i = 0;
     let ctdArrFormerLength = contentTypeDefinitions.length;
-    let spinnerStarted = false;
     let spinner;
     while (contentTypeDefinitions.length) {
         if (contentTypeDefinitions[i]) {

--- a/src/purifier/purifier.js
+++ b/src/purifier/purifier.js
@@ -15,11 +15,11 @@ module.exports = purgeContentObjects = async (apiKey, internal = false, force = 
     let spinner;
     while (contentTypeDefinitions.length) {
         if (contentTypeDefinitions[i]) {
-            let notRemoved = await removeContentObjects(contentTypeDefinitions[i], apiKey);
-            if (!notRemoved) {
-                contentTypeDefinitions.splice(i, 1);
-            } else {
+            let objectsNotPurged = await removeContentObjects(contentTypeDefinitions[i], apiKey);
+            if (objectsNotPurged) {
                 i++;
+            } else {
+                contentTypeDefinitions.splice(i, 1);
             }
         } else {
             i = 0;
@@ -63,24 +63,24 @@ const dropRelations = (contentTypeDefinitions, apiKey) => {
     const clearContentType = async (ctd) => {
         let ctdWithDroppedRelations = cloneObject(ctd);
         for (let property in ctd.metaDefinition.propertiesConfig) {
-            if (ctd.metaDefinition.propertiesConfig[property]?.validation?.hasOwnProperty("relationContenttype")) {
+            const isRelationField = ctd.metaDefinition.propertiesConfig[property]?.validation?.hasOwnProperty("relationContenttype");
+            if (isRelationField) {
                 ctdWithDroppedRelations = removeProperty(ctdWithDroppedRelations, property);
             }
         }
         await updateContentTypeDefinition(ctdWithDroppedRelations, apiKey);
         await updateContentTypeDefinition(ctd, apiKey);
-        return;
     }
     
     for (let ctd in contentTypeDefinitions) {
         for (let property in contentTypeDefinitions[ctd].metaDefinition.propertiesConfig) {
-            if (contentTypeDefinitions[ctd].metaDefinition.propertiesConfig[property]?.validation?.hasOwnProperty("relationContenttype")) {
+            const isCtdWithRelations = contentTypeDefinitions[ctd].metaDefinition.propertiesConfig[property]?.validation?.hasOwnProperty("relationContenttype");
+            if (isCtdWithRelations) {
                 return clearContentType(contentTypeDefinitions[ctd]);
             }
         }
     }
 }
-
 
 const removeContentObjects = async (contentTypeDefinition, apiKey) => {
 

--- a/src/purifier/purifier.js
+++ b/src/purifier/purifier.js
@@ -51,7 +51,7 @@ module.exports = purgeContentObjects = async (apiKey, internal = false, force = 
     }
     clearInterval(loading);
     if (ctdsClearedOfRelations > 0) {
-        console.log(`I\'m finishing, all Content objects have been purged`);
+        console.log(`I\'m finished, all Content objects have been purged`);
     }
 }
 


### PR DESCRIPTION
Purge will now work better, looping over the same CTDs if relations dont allow for CO removal. Function call in command.js has also been fixed
Adds flag `--force` for removing data even if CTD's relations loop to each other.
Switches `withInternal` option to flag (`--withInternal` or `--internal`)