### PR TITLE
Feature/21726-excel-migrator

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,16 +106,12 @@ This command exports data from the Flotiq account to local JSON files. If the ke
 
 ### Import data from Contentful to Flotiq
 
-The `contentful-import` command will automatically pull content types, assets and content objects from Contentful space to your Flotiq account.
-
-Execute:
 `flotiq contentful-import [contentfulSpaceId] [contentfulContentManagementToken] [flotiqApiKey] [translation]`
 
-or in development:
+This command will automatically pull content types, assets and content objects from Contentful space to your Flotiq account.
 
-`node bin/flotiq contentful-import [contentfulSpaceId] [contentfulContentManagementToken] [flotiqApiKey] [translation]`
-
-`[translation]` - selection of Contentful's locale. en-US by default.
+**Parameters**
+* `[translation]` - selection of Contentful's locale. en-US by default.
 
 ### Display stats
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ This command will automatically pull content types, assets and content objects f
 
 ### Export data from Flotiq to MS Excel
 
-`flotiq excel-import [ctdName] [filePath] [flotiqApiKey]`
+`flotiq excel-export [ctdName] [filePath] [flotiqApiKey]`
 
 This command will export Content Objects from the given Content Type to an MS Excel file in .xlsx format.
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,36 @@ This command will automatically pull content types, assets and content objects f
 **Parameters**
 * `[translation]` - selection of Contentful's locale. en-US by default.
 
+### Export data from Flotiq to MS Excel
+
+`flotiq excel-import [ctdName] [filePath] [flotiqApiKey]`
+
+This command will export Content Objects from the given Content Type to an MS Excel file in .xlsx format.
+
+**Parameters**
+* `ctdName` - API name of Content Type Definition you wish to export,
+* `filePath` - the directory to which the xlsx file is to be saved. Type in "." if you want to save the file inside the current directory,
+* `flotiqApiKey` - API key to your Flotiq account with read permission.
+
+**Flags**
+* `--limit=[number]` or `--l=[number]` - number of Content Objects to export counting from the top row, default: 10.000,
+* `--hideResults` or `--hr` - information about the export process will not appear in the console.
+
+### Import data to Flotiq from MS Excel
+
+`flotiq excel-import [ctdName] [filePath] [flotiqApiKey]`
+
+This command will import Content Objects from an MS Excel file to the given Content Type.
+
+**Parameters**
+* `ctdName` - API name of Content Type Definition you wish to import data to,
+* `filePath` - the directory to the xlsx file you wish to import data from,
+* `flotiqApiKey` - API key to your Flotiq account with read and write permissions.
+
+**Flags**
+* `--limit=[number]` or `--l=[number]` - number of Content Objects imported counting from the top row, default: 10 000,
+* `--hideResults` or `--hr` - information about the import process will not appear in the console.
+
 ### Display stats
 
 `flotiq stats [flotiqApiKey]`

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ This command exports data from the Flotiq account to local JSON files. If the ke
 This command will automatically pull content types, assets and content objects from Contentful space to your Flotiq account.
 
 **Parameters**
-* `[translation]` - selection of Contentful's locale. en-US by default.
+* `[translation]` - selection of Contentful's locale. en-US by default
 
 ### Export data from Flotiq to MS Excel
 
@@ -120,13 +120,13 @@ This command will automatically pull content types, assets and content objects f
 This command will export Content Objects from the given Content Type to an MS Excel file in .xlsx format.
 
 **Parameters**
-* `ctdName` - API name of Content Type Definition you wish to export,
-* `filePath` - the directory to which the xlsx file is to be saved. Type in "." if you want to save the file inside the current directory,
-* `flotiqApiKey` - API key to your Flotiq account with read permission.
+* `ctdName` - API name of Content Type Definition you wish to export
+* `filePath` - the directory to which the xlsx file is to be saved. Type in "." if you want to save the file inside the current directory
+* `flotiqApiKey` - API key to your Flotiq account with read permission
 
 **Flags**
-* `--limit=[number]` or `--l=[number]` - number of Content Objects to export counting from the top row, default: 10.000,
-* `--hideResults` or `--hr` - information about the export process will not appear in the console.
+* `--limit=[number]` or `--l=[number]` - number of Content Objects to export counting from the top row, default: 10000
+* `--hideResults` or `--hr` - information about the export process will not appear in the console
 
 ### Import data to Flotiq from MS Excel
 
@@ -135,13 +135,13 @@ This command will export Content Objects from the given Content Type to an MS Ex
 This command will import Content Objects from an MS Excel file to the given Content Type.
 
 **Parameters**
-* `ctdName` - API name of Content Type Definition you wish to import data to,
-* `filePath` - the directory to the xlsx file you wish to import data from,
-* `flotiqApiKey` - API key to your Flotiq account with read and write permissions.
+* `ctdName` - API name of Content Type Definition you wish to import data to
+* `filePath` - the path to the xlsx file you wish to import data from
+* `flotiqApiKey` - API key to your Flotiq account with read and write permissions
 
 **Flags**
-* `--limit=[number]` or `--l=[number]` - number of Content Objects imported counting from the top row, default: 10 000,
-* `--hideResults` or `--hr` - information about the import process will not appear in the console.
+* `--limit=[number]` or `--l=[number]` - number of Content Objects imported counting from the top row, default: 10 000
+* `--hideResults` or `--hr` - information about the import process will not appear in the console
 
 ### Display stats
 
@@ -157,7 +157,7 @@ This command displays your Flotiq API Key following statistics:
 
 ## Flags
 
-`--json-output`, `-j` - Error and console output will be additionally written into json file named `output.json`.
+`--json-output`, `-j` - Error and console output will be additionally written into json file named `output.json`
 
 
 ## Gatsby Starters

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@contentful/rich-text-html-renderer": "^15.13.1",
     "contentful-export": "^7.18.12",
     "dotenv": "^16.0.0",
+    "flotiq-excel-migrator": "^1.0.13",
     "flotiq-wordpress-import": "^1.1.7",
     "form-data": "^3.0.0",
     "gatsby-cli": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,16 @@
   },
   "keywords": [
     "flotiq",
-    "gatsby"
+    "gatsby",
+    "cms",
+    "headless",
+    "content"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/flotiq/flotiq-cli.git"
+  },
+  "homepage": "https://github.com/flotiq/flotiq-cli",
   "author": "Flotiq team <hello@flotiq.com>",
   "license": "MIT",
   "dependencies": {

--- a/src/command/command.js
+++ b/src/command/command.js
@@ -71,7 +71,7 @@ yargs
         console = custom.console(oldConsole, yargs.argv['json-output'], errors, stdOut, errorObject, fs);
         if (yargs.argv._.length < 2) {
             const answers = await askQuestions(questionsText.IMPORT_QUESTIONS);
-            let {flotiqApiKey, projectDirectory} = answers;
+            let { flotiqApiKey, projectDirectory } = answers;
             let directory = getObjectDataPath(projectDirectory);
             await importer.importer(flotiqApiKey, directory, true);
         } else if (yargs.argv._.length === 2 && apiKeyDefinedInDotEnv()) {
@@ -94,7 +94,7 @@ yargs
         // overriding the console in this case is not required, custom console is build in wordpress-importer
         if (yargs.argv._.length < 2) {
             const answers = await askQuestions(questionsText.WORDPRESS_IMPORT_QUESTIONS);
-            let {flotiqApiKey, wordpressUrl} = answers;
+            let { flotiqApiKey, wordpressUrl } = answers;
             await wordpressStart(flotiqApiKey, wordpressUrl, yargs.argv['json-output'])
         } else if (yargs.argv._.length === 2 && apiKeyDefinedInDotEnv()) {
             await wordpressStart.run(process.env.FLOTIQ_API_KEY, argv.wordpressUrl, yargs.argv['json-input']);
@@ -128,11 +128,11 @@ yargs
         }, async (argv) => {
             if (yargs.argv._.length < 2 && !apiKeyDefinedInDotEnv()) {
                 console.log('Api key not found')
-            } else if(yargs.argv._.length === 1 && apiKeyDefinedInDotEnv()) {
+            } else if (yargs.argv._.length === 1 && apiKeyDefinedInDotEnv()) {
                 await purgeContentObjects(argv.flotiqApiKey, argv.withInternal);
             } else if (yargs.argv._.length === 2) {
                 const answers = await askQuestions(questionsText.PURGE_QUESTION);
-                const {confirmation} = answers;
+                const { confirmation } = answers;
                 if (!argv.flotiqApiKey && apiKeyDefinedInDotEnv()) {
                     argv.flotiqApiKey = process.env.FLOTIQ_API_KEY;
                 }
@@ -160,7 +160,7 @@ yargs
             console = custom.console(oldConsole, yargs.argv['json-output'], errors, stdOut, errorObject, fs);
             if (yargs.argv._.length < 2) {
                 const answers = await askQuestions(questionsText.EXPORT_QUESTIONS);
-                let {flotiqApiKey, projectDirectory} = answers;
+                let { flotiqApiKey, projectDirectory } = answers;
                 await exporter.export(flotiqApiKey, projectDirectory, onlyDefinitions);
             } else if (yargs.argv._.length === 2 && apiKeyDefinedInDotEnv()) {
                 await exporter.export(process.env.FLOTIQ_API_KEY, argv.directory, onlyDefinitions);
@@ -186,7 +186,7 @@ yargs
         }
         if (yargs.argv._.length < 3) {
             let answers = await askQuestions(questionsText.INSTALL_SDK);
-            let {language, projectDirectory, apiKey} = answers;
+            let { language, projectDirectory, apiKey } = answers;
             await sdk(language, projectDirectory, apiKey);
         } else if (yargs.argv._.length === 4 && apiKeyDefinedInDotEnv()) {
             await sdk(argv.language, argv.directory, process.env.FLOTIQ_API_KEY);
@@ -197,6 +197,51 @@ yargs
             process.exit(1);
         }
     })
+    .command('excel-import [flotiqApiKey] [ctdName] [filePath]',
+        `Import Content Objects from excel file to Flotiq account`,
+        (yargs) => {
+            optionalParamFlotiqApiKey(yargs);
+            yargs
+                .boolean('logResults')
+                .alias('logResults', ['lr'])
+                .describe('logResults', 'whether to type out results into the console, default: false')
+                .boolean('updateExisting')
+                .alias('updateExisting', ['ue'])
+                .describe('updateExisting', 'wheather to update existing Content Objetcs, default: true')
+                .number('limit')
+                .alias('limit', ['l'])
+                .describe('number of Content Objects imported counting from the top row, default: 10 000')
+        }, async (argv) => {
+            // DEL
+            const test = (options) => {
+                console.log("options: ", options)
+            }
+            //
+            if (yargs.argv._.length < 3) {
+                const answers = await askQuestions(questionsText.EXCEL_EXPORT);
+                let { flotiqApiKey, ctdName, filePath } = answers;
+                test({
+                    apiKey: flotiqApiKey,
+                    ctdName: ctdName,
+                    filePath: filePath
+                });
+            } else if (yargs.argv._.length > 3 && yargs.argv._.length < 7) {
+                if (!argv.flotiqApiKey && apiKeyDefinedInDotEnv()) {
+                    argv.flotiqApiKey === process.env.FLOTIQ_API_KEY;
+                }
+                test({
+                    apiKey: argv.flotiqApiKey,
+                    ctdName: argv.ctdName,
+                    filePath: argv.filePath,
+                    limit: yargs.argv['limit'],
+                    logResults: yargs.argv['logResults'],
+                    updateExisting: yargs.argv['updateExisting']
+                });
+            } else {
+                yargs.showHelp();
+                process.exit(1);
+            }
+        })
     .command('stats [flotiqApiKey]', 'Display Flotiq stats', (yargs) => {
     }, async (argv) => {
 

--- a/src/command/command.js
+++ b/src/command/command.js
@@ -203,6 +203,14 @@ yargs
         (yargs) => {
             optionalParamFlotiqApiKey(yargs);
             yargs
+                .positional('ctdName', {
+                    describe: 'API name of Content Type Definition you wish to export',
+                    type: 'string'
+                })
+                .positional('filePath', {
+                    describe: 'the directory to which the xlsx file is to be saved, type in "." if you want to save the file inside the current directory',
+                    type: 'string'
+                })
                 .boolean('hideResults')
                 .alias('hideResults', ['hr'])
                 .describe('hideResults', 'information about export process will not appear in the console')
@@ -241,6 +249,14 @@ yargs
         (yargs) => {
             optionalParamFlotiqApiKey(yargs);
             yargs
+                .positional('ctdName', {
+                    describe: 'API name of Content Type Definition you wish to import data to',
+                    type: 'string'
+                })
+                .positional('filePath', {
+                    describe: 'the directory to the xlsx file you wish to import data from',
+                    type: 'string'
+                })
                 .boolean('hideResults')
                 .alias('hideResults', ['hr'])
                 .describe('hideResults', 'information about export process will not appear in the console')

--- a/src/command/command.js
+++ b/src/command/command.js
@@ -259,10 +259,10 @@ yargs
                 })
                 .boolean('hideResults')
                 .alias('hideResults', ['hr'])
-                .describe('hideResults', 'information about export process will not appear in the console')
+                .describe('hideResults', 'information about import process will not appear in the console')
                 .number('limit')
                 .alias('limit', ['l'])
-                .describe('number of Content Objects imported counting from the top row, default: 10 000')
+                .describe('number of Content Objects imported counting from the top row, default: 10.000')
         }, async (argv) => {
             if (yargs.argv._.length < 3 || (yargs.argv._.length === 3 && !apiKeyDefinedInDotEnv())) {
                 const answers = await askQuestions(questionsText.EXCEL_MIGRATION);

--- a/src/command/questions.js
+++ b/src/command/questions.js
@@ -47,6 +47,18 @@ const LANGUAGE = {
     message: "SDK language to install",
     defaultAnswer: 'javascript'
 }
+const CONTENT_TYPE_NAME = {
+    name: "ctdName",
+    type: "input",
+    message: "API Name of the Content Type Definition:"
+}
+
+const FILE_PATH = {
+    name: "filePath",
+    type: "input",
+    message: "File's directory path:"
+}
+
 const START_QUESTIONS = [
     FLOTIQ_RW_API_KEY,
     PROJECT_DIRECTORY,
@@ -84,6 +96,12 @@ const INSTALL_SDK = [
     FLOTIQ_API_KEY,
 ]
 
+const EXCEL_EXPORT = [
+    FLOTIQ_API_KEY,
+    CONTENT_TYPE_NAME,
+    FILE_PATH
+]
+
 const STATS = [
     FLOTIQ_API_KEY,
 ]
@@ -100,5 +118,6 @@ module.exports = {
     PURGE_QUESTION,
     EXPORT_QUESTIONS,
     INSTALL_SDK,
+    EXCEL_EXPORT,
     STATS
 }

--- a/src/command/questions.js
+++ b/src/command/questions.js
@@ -56,7 +56,7 @@ const CONTENT_TYPE_NAME = {
 const FILE_PATH = {
     name: "filePath",
     type: "input",
-    message: "File's directory path:"
+    message: "File's directory path ( `.` for current directory ):"
 }
 
 const START_QUESTIONS = [
@@ -96,7 +96,7 @@ const INSTALL_SDK = [
     FLOTIQ_API_KEY,
 ]
 
-const EXCEL_EXPORT = [
+const EXCEL_MIGRATION = [
     FLOTIQ_API_KEY,
     CONTENT_TYPE_NAME,
     FILE_PATH
@@ -118,6 +118,6 @@ module.exports = {
     PURGE_QUESTION,
     EXPORT_QUESTIONS,
     INSTALL_SDK,
-    EXCEL_EXPORT,
+    EXCEL_MIGRATION,
     STATS
 }


### PR DESCRIPTION
added new funcionality for migrating Flotiq Content Objects to/form MS Excel file. 
Info on how to use the new feature is in readme.md.
Together with this PR, a corresponding PR in Flotiq Docs should be merged.