### PR TITLE
prepare importer for relation validation on CTD creation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flotiq-cli",
-  "version": "2.9.1",
+  "version": "2.10.0",
   "description": "Flotiq CLI",
   "main": "src/command/command.js",
   "private": false,

--- a/src/flotiq-api.js
+++ b/src/flotiq-api.js
@@ -287,7 +287,7 @@ module.exports = class FlotiqApi {
           await new Promise(resolve => setTimeout(resolve, 1000)); // Retry after 1 second
           return this._sendRequest(uri, batch, method); // Retry request
         } else {
-          console.dir(e.response.data.errors, { depth: undefined });
+          console.dir(e.response?.data?.errors, { depth: undefined });
           throw new Error(e.message);
         }
       }


### PR DESCRIPTION
This PR prepares the importer for future additional validation, which checks if the relations specified in the fields validation of the content type exist before accepting the content type to be saved.