### PR TITLE
Add publish options to CLI

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) (you find TL;DR at the end of this change log),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.12.0]
+### Added
+* `--publish` option to import command to publish automatically objects with status public
+* `--with-internal` option to export command to persist information about object status for publication in import
+
 ## [2.11.0]
 ### Added
 * import/export plugin settings objects #26641

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flotiq-cli",
-  "version": "2.11.1",
+  "version": "2.12.0",
   "description": "Flotiq CLI",
   "main": "src/command/command.js",
   "private": false,

--- a/src/flotiq-api.js
+++ b/src/flotiq-api.js
@@ -116,6 +116,12 @@ module.exports = class FlotiqApi {
     return this.middleware.post(uri, obj);
   }
 
+  async publishContentObject(type, obj) {
+    const uri = `/content/${type}/${obj.id}/publish`;
+
+    return this.middleware.post(uri, obj);
+  }
+
   async persistContentObjectBatch(ctd, obj) {
     assert(typeof ctd, 'string');
     assert(Array.isArray(obj));

--- a/tests/commands/importer.test.js
+++ b/tests/commands/importer.test.js
@@ -62,7 +62,9 @@ describe('importer', () => {
         });
         const expectedResult = [
             [{ctdName: "mockContentType", featuredImage: undefined}],
-            [{name: "mockContentType"}]]
+            [{name: "mockContentType"}],
+            [],
+          ]
         ;
         const result = await importer(
             mockDirectory,


### PR DESCRIPTION
Added:
* `--publish` option to import the command to publish automatically objects with status public,
* `--with-internal` option to export command to persist information about object status for publication in import.

This adds the possibility to make full import/export with automatic publication.