### PR TITLE
Use Axios interceptors for throttling and rate limits

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) (you find TL;DR at the end of this change log),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.13.0]
+### Changed
+* Rate limit retries and throttling now happen through interceptors. This way no api calls should fail due to 429 errors and media uploads can happen faster as first uploaded file doesn't trigger throttling.
+
 ## [2.12.2]
 ### Fixed
 * possibility to put the flotiq api url into the importer handler also applies to media

--- a/commands/importer.js
+++ b/commands/importer.js
@@ -10,7 +10,7 @@ const FlotiqApi = require("./../src/flotiq-api");
 const config = require("./../src/configuration/config");
 const {mediaImporter} = require("./../src/media");
 const axios = require("axios");
-const {shouldUpdate } = require("./../src/util");
+const {shouldUpdate, rateLimitInterceptor, throttleInterceptor } = require("./../src/util");
 const {readCTDs} = require("../src/util");
 
 const WEBHOOKS_MESSAGE_403 = 'It looks like the api key does not have access to webhooks, it continues without deactivating webhooks';
@@ -492,11 +492,12 @@ async function handler(argv) {
         timeout: flotiqApi.timeout,
         headers: flotiqApi.headers,
     });
+    rateLimitInterceptor(mediaApi, logger, 1000 / writePerSecondLimit);
+    throttleInterceptor(mediaApi, 1000 / writePerSecondLimit);
     let replacements = await mediaImporter(
       directory,
       flotiqApi,
       mediaApi,
-      writePerSecondLimit,
     );
 
     await featuredImagesImport(

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "yargs": "^17.7.2"
   },
   "devDependencies": {
+    "axios-mock-adapter": "^2.1.0",
     "jest": "^29.7.0",
     "jest-when": "^3.6.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flotiq-cli",
-  "version": "2.12.3",
+  "version": "2.13.0",
   "description": "Flotiq CLI",
   "main": "src/command/command.js",
   "private": false,

--- a/tests/media.test.js
+++ b/tests/media.test.js
@@ -1,11 +1,16 @@
 const fs = require('fs/promises');
 const FlotiqApi = require('./../src/flotiq-api');
 const { mediaImporter } = require('./../src/media');
+const axios = require('axios');
+const { rateLimitInterceptor, throttleInterceptor } = require('./../src/util');
+const AxiosMockAdapter = require("axios-mock-adapter");
+const logger = require('./../src/logger');
 
-jest.mock('axios');
+// This sets the mock adapter on the default instance
+const mock = new AxiosMockAdapter(axios);
+
 jest.mock('fs/promises');
 jest.mock('node-fetch');
-jest.mock('./../src/flotiq-api');
 jest.mock('./../src/logger', () => ({
     info: jest.fn(),
     warn: jest.fn(),
@@ -16,94 +21,88 @@ describe('mediaImporter', () => {
     const mockDirectory = '/mock/directory';
     const mockApiUrl = 'https://dummy-api.flotiq.com';
     const mockApiKey = 'dummyApiKey';
+    
+    function mockFileCount(count) {
+        const files = new Array(count).fill(null).map((_, number) => ({
+            id: `file${number}`,
+            url: `/image/0x0/dummy_media_id${number}.jpg`,
+            mimeType: 'image/png',
+            extension: 'png',
+            fileName: `file${number}.png`
+        }));
+        fs.readFile.mockResolvedValue(JSON.stringify(files));
+    }
 
     beforeEach(() => {
         jest.clearAllMocks();
-
-        FlotiqApi.mockImplementation(() => ({
-            fetchContentTypeDefinition: jest.fn().mockResolvedValue([]),
-            fetchContentTypeDefs: jest.fn().mockResolvedValue([]),
-            updateContentTypeDefinition: jest.fn(),
-            fetchContentObjects: jest.fn().mockResolvedValue([]),
-            patchContentObjectBatch: jest.fn(),
-            persistContentObjectBatch: jest.fn(),
-            createOrUpdate: jest.fn().mockResolvedValue({
-                ok: true,
-                json: jest.fn().mockResolvedValue({success:true})
-            }),
-            middleware: {
-                put: jest.fn(),
-                delete: jest.fn().mockResolvedValue(undefined)
-            }
-        }));
+        mock.onGet(new RegExp(`${mockApiUrl}/api/v1/internal/contenttype.*`)).reply(200, {
+            data: []
+        });
 
         global.fetch = jest.fn(() =>
             Promise.resolve({
                 status: 404, // fetch should return 404 for importer to send postMedia request
             })
         );
-    
-        // Mock fs.readFile
-        fs.readFile.mockResolvedValue(
-            JSON.stringify([
-                {
-                    id: 'file1',
-                    url: '/image/0x0/dummy_media_id.jpg',
-                    mimeType: 'image/png',
-                    extension: 'png',
-                    fileName: 'file1.png'
-                }
-            ])
-        );
     });
 
-
+    afterEach(() => {
+        mock.reset();
+    });
 
     it('should retry on 429 error during media upload', async () => {
+        mockFileCount(1);
+        const url = new RegExp(`${mockApiUrl}/api/media`);
+        mock
+         .onPost(url).replyOnce(429)
+         .onPost(url).replyOnce(429)
+         .onPost(url).reply(200, {
+             id: 'new-media-id'
+         });
+        
         const flotiqApi = new FlotiqApi(`${mockApiUrl}/api/v1`,  mockApiKey, {
             batchSize: 100,
         });
         flotiqApi.flotiqApiUrl = mockApiUrl;
+        const mediaApi = axios.create({
+            baseURL: `${mockApiUrl}/api/media`,
+            timeout: flotiqApi.timeout,
+            headers: flotiqApi.headers,
+        });
+        rateLimitInterceptor(mediaApi, logger, 1);
 
-        const mockMediaApi = {
-            post: jest.fn()
-                .mockRejectedValueOnce({
-                    response: { 
-                        status: 429, 
-                        message: 'Too Many Requests' 
-                    }
-                })
-                .mockResolvedValueOnce({
-                    data: { id: 'new-media-id' }
-                })
-        };
+        await mediaImporter(mockDirectory, flotiqApi, mediaApi);
 
-        await mediaImporter(mockDirectory, flotiqApi, mockMediaApi, 1);
-
-        expect(mockMediaApi.post).toHaveBeenCalledTimes(2);
+        expect(mock.history.post.length).toBe(3);
+        expect(mock.history.post[1]._retryCount).toEqual(2);
     });
 
     it('should respect writePerSecondLimit and throttle uploads', async () => {
+        mockFileCount(2); // one file would be instant, two files should trigger throttling
+        const url = new RegExp(`${mockApiUrl}/api/media`);
+        mock
+         .onPost(url).reply(200, {
+             id: 'new-media-id'
+         });
+        
         const flotiqApi = new FlotiqApi(`${mockApiUrl}/api/v1`,  mockApiKey, {
             batchSize: 100,
         });
         flotiqApi.flotiqApiUrl = mockApiUrl;
-
-        const mockMediaApi = {
-            post: jest.fn()
-                .mockResolvedValueOnce({
-                    data: { id: 'new-media-id' }
-                })
-        };
-
+        const mediaApi = axios.create({
+            baseURL: `${mockApiUrl}/api/media`,
+            timeout: flotiqApi.timeout,
+            headers: flotiqApi.headers,
+        });
+        rateLimitInterceptor(mediaApi, logger, 1);
+        throttleInterceptor(mediaApi, 1000); // 1 request per second
         const start = Date.now();
-        await mediaImporter(mockDirectory, flotiqApi, mockMediaApi, 1); // writePerSecondLimit = 1
+        await mediaImporter(mockDirectory, flotiqApi, mediaApi);
 
         const end = Date.now();
         const elapsed = end - start;
-
-        expect(mockMediaApi.post).toHaveBeenCalledTimes(1);
+        expect(mock.history.post.length).toBe(2);
         // Check that importer respected throttle limit
-        expect(elapsed).toBeGreaterThanOrEqual(1000); // at least 1 second
+        expect(elapsed).toBeGreaterThanOrEqual(1000); // at least 1 second for 2 uploads
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1173,6 +1173,14 @@ available-typed-arrays@^1.0.7:
   dependencies:
     possible-typed-array-names "^1.0.0"
 
+axios-mock-adapter@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/axios-mock-adapter/-/axios-mock-adapter-2.1.0.tgz#25ab2d7558f915e391744a40bbeb7374ad5985a4"
+  integrity sha512-AZUe4OjECGCNNssH8SOdtneiQELsqTsat3SQQCWLPjN436/H+L9AjWfV7bF+Zg/YL9cgbhrz5671hoh+Tbn98w==
+  dependencies:
+    fast-deep-equal "^3.1.3"
+    is-buffer "^2.0.5"
+
 axios@^1.7.2, axios@^1.7.4:
   version "1.8.4"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.8.4.tgz#78990bb4bc63d2cae072952d374835950a82f447"
@@ -2397,6 +2405,11 @@ fast-copy@^3.0.0:
   resolved "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.2.tgz"
   integrity sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==
 
+fast-deep-equal@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
+  integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
+
 fast-json-stable-stringify@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz"
@@ -3097,6 +3110,11 @@ is-boolean-object@^1.2.1:
   dependencies:
     call-bound "^1.0.2"
     has-tostringtag "^1.0.2"
+
+is-buffer@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.5.tgz#ebc252e400d22ff8d77fa09888821a24a658c191"
+  integrity sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==
 
 is-callable@^1.1.3, is-callable@^1.2.7:
   version "1.2.7"


### PR DESCRIPTION
Currently the CLI uses handmade methods for throttling and rate limiting. This causes:
- 429 rate limit errors in places that are not protected
- unnecessary delay when first file is uploaded

With axios interceptors approach, both of those issues can be fixed and import code is tiny bit simpler.